### PR TITLE
server-node: handle null or malformed certs on auto update

### DIFF
--- a/src/server-node.js
+++ b/src/server-node.js
@@ -510,12 +510,34 @@ function systemUp() {
 }
 
 /**
+ * Schedules the next cert-update attempt after a backoff delay.
+ * The delay decreases as attempts are exhausted, and is clamped so that
+ * the retry fires no later than one minute before the cert expires.
+ * @param {tls.TlsOptions} secopts
+ * @param {tls.Server} s
+ * @param {int} n - already-incremented attempt count
+ * @param {number} validUntil - ms until the current cert expires (may be ≤ 0)
+ * @returns {number} scheduled delay in ms
+ */
+function scheduleCertBackoff(secopts, s, n, validUntil) {
+  const oneMinMs = 1 * 60 * 1000;
+  const sixMinMs = 6 * 60 * 1000;
+  const attemptsLeft = Math.max(1, maxCertUpdateAttempts - n);
+  let when = validUntil <= oneMinMs ? oneMinMs : sixMinMs * attemptsLeft;
+  if (validUntil > oneMinMs && when > validUntil) {
+    when = Math.max(oneMinMs, validUntil - oneMinMs);
+  }
+  util.timeout(when, () => certUpdateForever(secopts, s, n));
+  return when;
+}
+
+/**
  * @param {tls.TlsOptions} secopts
  * @param {tls.Server} s
  * @param {int} n
  */
 async function certUpdateForever(secopts, s, n = 0) {
-  if (n > maxCertUpdateAttempts) {
+  if (n >= maxCertUpdateAttempts) {
     log2.e("crt: max update attempts reached", n);
     return false;
   }
@@ -527,10 +549,18 @@ async function certUpdateForever(secopts, s, n = 0) {
 
   // nodejs.org/api/tls.html#tlsgetcertificates
   // nodejs.org/api/tls.html#certificate-object
-  const crt = new X509Certificate(crtpem);
-
-  if (!crt) return false;
-  else logCertInfo(crt);
+  // X509Certificate throws on invalid input; it never returns null
+  let crt = null;
+  try {
+    crt = new X509Certificate(crtpem);
+  } catch (ex) {
+    log2.e("crt: #", n, "update: invalid cert pem", ex.message);
+    n = n + 1;
+    const when = scheduleCertBackoff(secopts, s, n, 0);
+    log2.e("crt: #", n, "update: next", when);
+    return false;
+  }
+  logCertInfo(crt);
 
   const oneDayMs = 24 * 60 * 60 * 1000; // in ms
   const validUntil = new Date(crt.validTo).getTime() - Date.now();
@@ -540,25 +570,34 @@ async function certUpdateForever(secopts, s, n = 0) {
     return false;
   }
 
-  const oneMinMs = 1 * 60 * 1000; // in ms
-  const sixMinMs = 6 * 60 * 1000; // in ms
   const [latestKey, latestCert] = await nodeutil.replaceKeyCert(crt);
   if (bufutil.emptyBuf(latestKey) || bufutil.emptyBuf(latestCert)) {
     n = n + 1;
-    const attemptsLeft = Math.max(1, maxCertUpdateAttempts - n);
-    let when = validUntil <= oneMinMs ? oneMinMs : sixMinMs * attemptsLeft;
-    if (validUntil > oneMinMs && when > validUntil) {
-      when = Math.max(oneMinMs, validUntil - oneMinMs);
-    }
+    const when = scheduleCertBackoff(secopts, s, n, validUntil);
     log2.e("crt: #", n, "update: no key/cert fetched; next", when);
-    util.timeout(when, () => certUpdateForever(secopts, s, n));
     return false;
   }
 
-  const latestcrt = new X509Certificate(latestCert);
+  // X509Certificate throws on invalid input; it never returns null
+  let latestcrt = null;
+  try {
+    latestcrt = new X509Certificate(latestCert);
+  } catch (ex) {
+    log2.e("crt: #", n, "update: invalid fetched cert", ex.message);
+    n = n + 1;
+    const when = scheduleCertBackoff(secopts, s, n, validUntil);
+    log2.e("crt: #", n, "update: next", when);
+    return false;
+  }
+  logCertInfo(latestcrt);
 
-  if (!latestcrt) return false;
-  else logCertInfo(latestcrt);
+  // same serial: remote cert not yet rotated; backoff and retry
+  if (latestcrt.serialNumber === crt.serialNumber) {
+    n = n + 1;
+    const when = scheduleCertBackoff(secopts, s, n, validUntil);
+    log2.i("crt: #", n, "update: same cert; backoff", when);
+    return false;
+  }
 
   secopts.cert = latestCert;
   secopts.key = latestKey;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches TLS certificate rotation and retry scheduling; mistakes could prevent timely cert refresh or cause retry storms, impacting service availability.
> 
> **Overview**
> Improves `certUpdateForever` to **gracefully handle malformed or invalid certificate PEMs** (both current and fetched) by catching `X509Certificate` parse failures and scheduling a retry instead of throwing.
> 
> Extracts the retry delay logic into `scheduleCertBackoff()` and tweaks the attempt limit check (`n >= maxCertUpdateAttempts`). Also adds a guard to back off when the fetched cert has the **same serial number** as the currently loaded cert, avoiding pointless reloading and tight loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b7fe52ecc053562d1fc425f9c5c6f984d37e11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->